### PR TITLE
Add image generation via AI/ML API

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -74,6 +74,7 @@ const sources = {
     novel: 'novel',
     vlad: 'vlad',
     openai: 'openai',
+    aimlapi: 'aimlapi',
     comfy: 'comfy',
     togetherai: 'togetherai',
     drawthings: 'drawthings',
@@ -1180,6 +1181,10 @@ async function onFalaiKeyClick() {
     return onApiKeyClick('FALAI API Key:', SECRET_KEYS.FALAI);
 }
 
+async function onAimlapiKeyClick() {
+    return onApiKeyClick('AI/ML API Key:', SECRET_KEYS.AIMLAPI);
+}
+
 function onBflUpsamplingInput() {
     extension_settings.sd.bfl_upsampling = !!$('#sd_bfl_upsampling').prop('checked');
     saveSettingsDebounced();
@@ -1303,6 +1308,7 @@ async function onModelChange() {
         sources.horde,
         sources.novel,
         sources.openai,
+        sources.aimlapi,
         sources.togetherai,
         sources.pollinations,
         sources.stability,
@@ -1505,6 +1511,9 @@ async function loadSamplers() {
         case sources.openai:
             samplers = ['N/A'];
             break;
+        case sources.aimlapi:
+            samplers = ['N/A'];
+            break;
         case sources.comfy:
             samplers = await loadComfySamplers();
             break;
@@ -1694,6 +1703,9 @@ async function loadModels() {
             break;
         case sources.openai:
             models = await loadOpenAiModels();
+            break;
+        case sources.aimlapi:
+            models = await loadAimlapiModels();
             break;
         case sources.comfy:
             models = await loadComfyModels();
@@ -1959,6 +1971,15 @@ async function loadOpenAiModels() {
     ];
 }
 
+async function loadAimlapiModels() {
+    $('#sd_aimlapi_key').toggleClass('success', !!secret_state[SECRET_KEYS.AIMLAPI]);
+    return [
+        { value: 'gpt-image-1', text: 'gpt-image-1' },
+        { value: 'dall-e-3', text: 'dall-e-3' },
+        { value: 'dall-e-2', text: 'dall-e-2' },
+    ];
+}
+
 async function loadVladModels() {
     if (!extension_settings.sd.vlad_url) {
         return [];
@@ -2078,6 +2099,9 @@ async function loadSchedulers() {
         case sources.openai:
             schedulers = ['N/A'];
             break;
+        case sources.aimlapi:
+            schedulers = ['N/A'];
+            break;
         case sources.togetherai:
             schedulers = ['N/A'];
             break;
@@ -2167,6 +2191,9 @@ async function loadVaes() {
             vaes = ['N/A'];
             break;
         case sources.openai:
+            vaes = ['N/A'];
+            break;
+        case sources.aimlapi:
             vaes = ['N/A'];
             break;
         case sources.togetherai:
@@ -2735,15 +2762,18 @@ async function sendGenerationRequest(generationType, prompt, additionalNegativeP
             case sources.auto:
                 result = await generateAutoImage(prefixedPrompt, negativePrompt, signal);
                 break;
-            case sources.novel:
-                result = await generateNovelImage(prefixedPrompt, negativePrompt, signal);
-                break;
-            case sources.openai:
-                result = await generateOpenAiImage(prefixedPrompt, signal);
-                break;
-            case sources.comfy:
-                result = await generateComfyImage(prefixedPrompt, negativePrompt, signal);
-                break;
+        case sources.novel:
+            result = await generateNovelImage(prefixedPrompt, negativePrompt, signal);
+            break;
+        case sources.openai:
+            result = await generateOpenAiImage(prefixedPrompt, signal);
+            break;
+        case sources.aimlapi:
+            result = await generateAimlapiImage(prefixedPrompt, signal);
+            break;
+        case sources.comfy:
+            result = await generateComfyImage(prefixedPrompt, negativePrompt, signal);
+            break;
             case sources.togetherai:
                 result = await generateTogetherAIImage(prefixedPrompt, negativePrompt, signal);
                 break;
@@ -3325,6 +3355,30 @@ async function generateOpenAiImage(prompt, signal) {
     }
 }
 
+async function generateAimlapiImage(prompt, signal) {
+    const result = await fetch('/api/aimlapi/generate-image', {
+        method: 'POST',
+        headers: getRequestHeaders(),
+        signal: signal,
+        body: JSON.stringify({
+            prompt: prompt,
+            model: extension_settings.sd.model,
+            n: 1,
+            size: `${extension_settings.sd.width}x${extension_settings.sd.height}`,
+            quality: extension_settings.sd.openai_quality,
+            style: extension_settings.sd.openai_style,
+        }),
+    });
+
+    if (result.ok) {
+        const data = await result.json();
+        return { format: 'png', data: data?.data[0]?.b64_json };
+    } else {
+        const text = await result.text();
+        throw new Error(text);
+    }
+}
+
 /**
  * Generates an image in ComfyUI using the provided prompt and configuration settings.
  *
@@ -3841,6 +3895,8 @@ function isValidState() {
             return secret_state[SECRET_KEYS.NOVEL];
         case sources.openai:
             return secret_state[SECRET_KEYS.OPENAI];
+        case sources.aimlapi:
+            return secret_state[SECRET_KEYS.AIMLAPI];
         case sources.comfy:
             return true;
         case sources.togetherai:
@@ -4521,6 +4577,7 @@ jQuery(async () => {
     $('#sd_bfl_key').on('click', onBflKeyClick);
     $('#sd_bfl_upsampling').on('input', onBflUpsamplingInput);
     $('#sd_falai_key').on('click', onFalaiKeyClick);
+    $('#sd_aimlapi_key').on('click', onAimlapiKeyClick);
 
     if (!CSS.supports('field-sizing', 'content')) {
         $('.sd_settings .inline-drawer-toggle').on('click', function () {

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -46,6 +46,7 @@
                 <option value="nanogpt">NanoGPT</option>
                 <option value="novel">NovelAI Diffusion</option>
                 <option value="openai">OpenAI</option>
+                <option value="aimlapi">AI/ML API</option>
                 <option value="pollinations">Pollinations</option>
                 <option value="vlad">SD.Next (vladmandic)</option>
                 <option value="stability">Stability AI</option>
@@ -139,7 +140,7 @@
                 </div>
                 <i>Hint: Save an API key in the NovelAI API settings to use it here.</i>
             </div>
-            <div data-sd-source="openai">
+            <div data-sd-source="openai,aimlapi">
                 <small data-i18n="These settings only apply to DALL-E 3">These settings only apply to DALL-E 3</small>
                 <div class="flex-container">
                     <div class="flex1">
@@ -155,6 +156,15 @@
                             <option value="standard" data-i18n="Standard">Standard</option>
                             <option value="hd" data-i18n="HD">HD</option>
                         </select>
+                    </div>
+                </div>
+            </div>
+            <div data-sd-source="aimlapi">
+                <div class="flex-container flexnowrap alignItemsBaseline marginBot5">
+                    <strong class="flex1" data-i18n="API Key">API Key</strong>
+                    <div id="sd_aimlapi_key" class="menu_button menu_button_icon">
+                        <i class="fa-fw fa-solid fa-key"></i>
+                        <span data-i18n="Click to set">Click to set</span>
                     </div>
                 </div>
             </div>

--- a/src/endpoints/aimlapi.js
+++ b/src/endpoints/aimlapi.js
@@ -1,0 +1,39 @@
+import express from 'express';
+import fetch from 'node-fetch';
+
+import { readSecret, SECRET_KEYS } from './secrets.js';
+
+export const router = express.Router();
+
+router.post('/generate-image', async (request, response) => {
+    try {
+        const key = readSecret(request.user.directories, SECRET_KEYS.AIMLAPI);
+
+        if (!key) {
+            console.warn('No AI/ML API key found');
+            return response.sendStatus(400);
+        }
+
+        console.debug('AI/ML API image request', request.body);
+        const result = await fetch('https://api.aimlapi.com/v1/images/generations', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${key}`,
+            },
+            body: JSON.stringify(request.body),
+        });
+
+        if (!result.ok) {
+            const text = await result.text();
+            console.warn('AI/ML API request failed', result.statusText, text);
+            return response.status(500).send(text);
+        }
+
+        const data = await result.json();
+        return response.json(data);
+    } catch (error) {
+        console.error(error);
+        response.status(500).send('Internal server error');
+    }
+});

--- a/src/server-startup.js
+++ b/src/server-startup.js
@@ -46,6 +46,7 @@ import { router as textCompletionsRouter } from './endpoints/backends/text-compl
 import { router as scaleAltRouter } from './endpoints/backends/scale-alt.js';
 import { router as speechRouter } from './endpoints/speech.js';
 import { router as azureRouter } from './endpoints/azure.js';
+import { router as aimlapiRouter } from './endpoints/aimlapi.js';
 
 /**
  * @typedef {object} ServerStartupResult
@@ -173,6 +174,7 @@ export function setupPrivateEndpoints(app) {
     app.use('/api/backends/scale-alt', scaleAltRouter);
     app.use('/api/speech', speechRouter);
     app.use('/api/azure', azureRouter);
+    app.use('/api/aimlapi', aimlapiRouter);
 }
 
 /**


### PR DESCRIPTION
## Summary
- implement `/api/aimlapi/generate-image` for AI/ML API
- hook aimlapi router in server startup
- support Aimlapi as image source in Stable Diffusion extension
- expose Aimlapi settings and API key fields in UI

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684321e680308329ba4469a75ad67565